### PR TITLE
using builder pattern to reduce the docker images size from 383MB-21MB

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine
+FROM golang:1.14-alpine AS builder
 
 RUN apk update && apk --no-cache add tzdata git
 
@@ -6,8 +6,10 @@ WORKDIR /app
 
 COPY . .
 
-RUN go mod vendor
+RUN go build -o /prediction-league ./service
 
-RUN go build -mod vendor -o ./bin/prediction-league ./service
+FROM alpine
 
-CMD ["./bin/prediction-league"]
+COPY --from=builder /prediction-league /prediction-league
+
+CMD ["/prediction-league"]


### PR DESCRIPTION
building the binary in a docker image, THEN copying just the compiled artefact out to a new clean image, this means the final docker image does not contain build dependencies (git, go runtime etc)